### PR TITLE
Enable flashcard page on frontend

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import HeaderNav from './components/HeaderNav'
 import UserProfile from './auth/pages/UserProfile'
 import AssessmentPage from "./assessments/pages/AssessmentPage.tsx";
 import ChatPage from "./chat/pages/ChatPage.tsx";
+import FlashcardPage from "./flashcards/pages/FlashcardPage.tsx";
 
 
 function App() {
@@ -16,6 +17,7 @@ function App() {
                 <Route path="/profile" element={<UserProfile/>}/>
                 <Route path="/assessments" element={<AssessmentPage/>}/>
                 <Route path="/chat" element={<ChatPage/>}/>
+                <Route path="/flashcards" element={<FlashcardPage/>}/>
                 <Route path="*" element={<NotFound/>}/>
             </Routes>
         </main>

--- a/frontend/src/components/NavLinks.tsx
+++ b/frontend/src/components/NavLinks.tsx
@@ -2,7 +2,7 @@ import { Link } from "react-router";
 
 const navLinks = [
     { label: "Home", to: "/" },
-
+    { label: "Flashcards", to: "/flashcards" },
 ];
 
 interface NavLinksProps {

--- a/frontend/src/flashcards/components/FlashcardItem.tsx
+++ b/frontend/src/flashcards/components/FlashcardItem.tsx
@@ -1,0 +1,16 @@
+import type { Flashcard } from "../types/flashcardTypes.ts";
+
+interface FlashcardItemProps {
+    flashcard: Flashcard;
+}
+
+const FlashcardItem = ({ flashcard }: FlashcardItemProps) => (
+    <div className="p-4 border rounded-lg shadow-sm bg-white">
+        <h3 className="font-semibold text-gray-900">{flashcard.question}</h3>
+        <p className="mt-2 text-gray-700 text-sm whitespace-pre-wrap">
+            {flashcard.answer}
+        </p>
+    </div>
+);
+
+export default FlashcardItem;

--- a/frontend/src/flashcards/components/FlashcardList.tsx
+++ b/frontend/src/flashcards/components/FlashcardList.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from "react";
+import Loader from "../../components/Loader.tsx";
+import { useFlashcardStore } from "../store/flashcardStore.ts";
+import FlashcardItem from "./FlashcardItem.tsx";
+
+const FlashcardList = () => {
+    const { flashcards, loadFlashcards, loading, error } = useFlashcardStore();
+
+    useEffect(() => {
+        loadFlashcards();
+    }, [loadFlashcards]);
+
+    if (loading) return <Loader />;
+    if (error) return <p className="text-red-500">{error}</p>;
+
+    return (
+        <div className="space-y-4">
+            {flashcards.map((card, idx) => (
+                <FlashcardItem key={idx} flashcard={card} />
+            ))}
+        </div>
+    );
+};
+
+export default FlashcardList;

--- a/frontend/src/flashcards/pages/FlashcardPage.tsx
+++ b/frontend/src/flashcards/pages/FlashcardPage.tsx
@@ -1,0 +1,13 @@
+import FlashcardList from "../components/FlashcardList.tsx";
+
+const FlashcardPage = () => (
+    <section className="bg-white grid place-content-center border-t border-gray-100">
+        <div className="mx-auto w-screen max-w-screen-xl px-4 py-16">
+            <div className="mx-auto max-w-xl">
+                <FlashcardList />
+            </div>
+        </div>
+    </section>
+);
+
+export default FlashcardPage;

--- a/frontend/src/flashcards/services/flashcardService.ts
+++ b/frontend/src/flashcards/services/flashcardService.ts
@@ -1,0 +1,9 @@
+import axios from "axios";
+import type { Flashcard } from "../types/flashcardTypes.ts";
+
+const API_URL = "http://localhost:5000/api";
+
+export const fetchFlashcards = async (): Promise<Flashcard[]> => {
+    const response = await axios.get<Flashcard[]>(`${API_URL}/flashcards/`);
+    return response.data;
+};

--- a/frontend/src/flashcards/store/flashcardStore.ts
+++ b/frontend/src/flashcards/store/flashcardStore.ts
@@ -1,0 +1,25 @@
+import { create } from "zustand";
+import { fetchFlashcards } from "../services/flashcardService.ts";
+import type { Flashcard } from "../types/flashcardTypes.ts";
+
+interface FlashcardState {
+    flashcards: Flashcard[];
+    loading: boolean;
+    error: string | null;
+    loadFlashcards: () => Promise<void>;
+}
+
+export const useFlashcardStore = create<FlashcardState>((set) => ({
+    flashcards: [],
+    loading: false,
+    error: null,
+    loadFlashcards: async () => {
+        set({ loading: true, error: null });
+        try {
+            const data = await fetchFlashcards();
+            set({ flashcards: data, loading: false });
+        } catch (err: any) {
+            set({ error: err.message ?? "Failed to load flashcards", loading: false });
+        }
+    },
+}));

--- a/frontend/src/flashcards/types/flashcardTypes.ts
+++ b/frontend/src/flashcards/types/flashcardTypes.ts
@@ -1,0 +1,5 @@
+export interface Flashcard {
+    question: string;
+    answer: string;
+    tags?: string[];
+}


### PR DESCRIPTION
## Summary
- add zustand store and API service for flashcards
- create flashcard list and item components
- expose flashcard page and route
- show flashcards link in navigation

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687539bc3628832286dd2126140211ff